### PR TITLE
docs: add examples for data export (issue #4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendMgf
 Title: Mass Spectrometry Data Backend for Mascot Generic Format (mgf) Files
-Version: 0.2.1
+Version: 0.2.2
 Authors@R:
     c(person(given = "RforMassSpectrometry Package Maintainer",
              email = "maintainer@rformassspectrometry.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # MsBackendMgf 0.2
 
+## Changes in 0.2.2
+
+- Add examples how to use the `MsBackendMgf` backend to export data to mgf
+  files (issue
+  [#4](https://github.com/rformassspectrometry/MsBackendMgf/issues/4).
+
+
 ## Changes in 0.2.0
 
 - Add `export` method to support exporting of data from a `Spectra` object in

--- a/R/MsBackendMgf.R
+++ b/R/MsBackendMgf.R
@@ -103,6 +103,22 @@ NULL
 #' ## The title is now available as variable named spectrumName
 #' be$spectrumName
 #'
+#' ## Next we create a Spectra object with this data
+#' sps <- Spectra(be)
+#'
+#' ## We can use the 'MsBackendMgf' also to export spectra data in mgf format.
+#' out_file <- tempfile()
+#' export(sps, backend = MsBackendMgf(), file = out_file, map = map)
+#'
+#' ## The first 20 lines of the generated file:
+#' readLines(out_file, n = 20)
+#'
+#' ## Next we add a new spectra variable to each spectrum
+#' sps$spectrum_idx <- seq_along(sps)
+#'
+#' ## This new spectra variable will also be exported to the mgf file:
+#' export(sps, backend = MsBackendMgf(), file = out_file, map = map)
+#' readLines(out_file, n = 20)
 NULL
 
 setClass("MsBackendMgf",
@@ -185,5 +201,11 @@ spectraVariableMapping <- function(format = c("mgf")) {
 setMethod("export", "MsBackendMgf", function(object, x, file = tempfile(),
                                              mapping = spectraVariableMapping(),
                                              ...) {
+    if (missing(x))
+        stop("Required parameter 'x' is missing. 'x' should be a 'Spectra' ",
+             "object with the full spectra data.")
+    if (!inherits(x, "Spectra"))
+        stop("Parameter 'x' is supposed to be a 'Spectra' object with the full",
+             " spectra data to be exported.")
     .export_mgf(x = x, con = file, mapping = mapping)
 })

--- a/R/functions-mgf.R
+++ b/R/functions-mgf.R
@@ -141,6 +141,11 @@
 .export_mgf <- function(x, con = stdout(), mapping = spectraVariableMapping()) {
     spv <- spectraVariables(x)
     spd <- spectraData(x, spv[!(spv %in% c("dataOrigin", "dataStorage"))])
+    col_not_ok <- !vapply(spd, is.vector, logical(1))
+    if (any(col_not_ok))
+        stop("Column(s) ", paste(colnames(spd)[col_not_ok], collapse = ", "),
+             " contain multiple elements per row. Please either drop this ",
+             "column or reduce its elements to a single value per row.")
     idx <- match(colnames(spd), names(mapping))
     colnames(spd)[!is.na(idx)] <- mapping[idx[!is.na(idx)]]
     l <- nrow(spd)

--- a/man/MsBackendMgf.Rd
+++ b/man/MsBackendMgf.Rd
@@ -111,6 +111,22 @@ be <- backendInitialize(MsBackendMgf(), fls, mapping = map)
 ## The title is now available as variable named spectrumName
 be$spectrumName
 
+## Next we create a Spectra object with this data
+sps <- Spectra(be)
+
+## We can use the 'MsBackendMgf' also to export spectra data in mgf format.
+out_file <- tempfile()
+export(sps, backend = MsBackendMgf(), file = out_file, map = map)
+
+## The first 20 lines of the generated file:
+readLines(out_file, n = 20)
+
+## Next we add a new spectra variable to each spectrum
+sps$spectrum_idx <- seq_along(sps)
+
+## This new spectra variable will also be exported to the mgf file:
+export(sps, backend = MsBackendMgf(), file = out_file, map = map)
+readLines(out_file, n = 20)
 }
 \author{
 Laurent Gatto and Johannes Rainer

--- a/tests/testthat/test_MsBackendMgf.R
+++ b/tests/testthat/test_MsBackendMgf.R
@@ -55,4 +55,13 @@ test_that("export,MsBackendMgf works", {
     res <- backendInitialize(MsBackendMgf(), fl)
     expect_equal(rtime(res), rtime(sps))
     expect_equal(peaksData(res), peaksData(sps@backend))
+
+    expect_error(export(MsBackendMgf(), file = fl), "missing")
+    expect_error(export(MsBackendMgf(), x = spd, file = fl), "spectra data to")
+
+    sps$lst <- list(1:3, c(4, 5, 2), c("a", "b"))
+    export(MsBackendMgf(), sps, file = fl)
+
+    sps$fail <- sps$mz
+    expect_error(export(MsBackendMgf(), sps, file = fl), "multiple elements")
 })


### PR DESCRIPTION
- Add data export example.
- Add additional input argument checks: fail if no `Spectra` object is
  submitted in the `export` call or if any of the columns is a S4 object.