### PR TITLE
added sorting of mz values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,11 @@ Authors@R:
       person(given = "Sebastian", family = "Gibb",
              comment = c(ORCID = "0000-0001-7406-4443"),
              email = "mail@sebastiangibb.de",
-             role = "aut"))
+             role = "aut"),
+      person(given = "Michael", family = "Witting",
+             comment = c(ORCID = "0000-0002-1462-4426"),
+             email = "michael.witting@helmholtz-muenchen.de",
+             role = "ctb"))
 Description: Mass spectrometry (MS) data backend supporting import and
 	     export of MS/MS spectra data from Mascot Generic Format
 	     (mgf) files. Objects defined in this package are supposed to be

--- a/R/functions-mgf.R
+++ b/R/functions-mgf.R
@@ -113,7 +113,9 @@ readMgf <- function(f, msLevel = 2L,
         ms <- matrix(numeric(), ncol = 2L)
     
     if(nrow(ms) > 1) {
-      ms <- ms[order(ms[, 1L]),]
+      if (is.unsorted(ms[, 1L])) {
+        ms <- ms[order(mz[, 1L]), , drop = FALSE]
+      }
     }
 
     r <- regexpr("=", desc, fixed = TRUE)

--- a/R/functions-mgf.R
+++ b/R/functions-mgf.R
@@ -111,6 +111,10 @@ readMgf <- function(f, msLevel = 2L,
 
     if (!length(ms) || length(ms) == 1L)
         ms <- matrix(numeric(), ncol = 2L)
+    
+    if(nrow(ms) > 1) {
+      ms <- ms[order(ms[, 1L]),]
+    }
 
     r <- regexpr("=", desc, fixed = TRUE)
     desc <- setNames(substring(desc, r + 1L, nchar(desc)),


### PR DESCRIPTION
Added sorting of m/z values. In rare cases I observed that m/z values in mgf files are not sorted, which leads to an error. This fixes the import of such files.